### PR TITLE
[Fix/#64-2] 서버 시간을 가져온 이후로 로컬에서 1월 1일 이후 판단 적용

### DIFF
--- a/src/pages/boardPage/components/board-header.tsx
+++ b/src/pages/boardPage/components/board-header.tsx
@@ -28,7 +28,7 @@ export function BoardHeader({
   screenWidth,
   onMenuClick,
 }: BoardHeaderProps) {
-  const { isNewYear } = useTimeStore();
+  const { isAfterNewYear } = useTimeStore();
   const navigate = useNavigate();
 
   // 화면 높이 가져오기
@@ -98,7 +98,7 @@ export function BoardHeader({
           zIndex: 40,
         }}
       >
-        {isNewYear ? (
+        {isAfterNewYear ? (
           <span className="font-normal font-year text-[24px] text-brown-200">
             HAPPY NEW YEAR
           </span>

--- a/src/pages/loginPage/components/new-year-countdown.tsx
+++ b/src/pages/loginPage/components/new-year-countdown.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from "react";
 import { useTimeStore } from "@/stores/useTimeStore";
 
 export function NewYearCountdown() {
-  const { serverTime, isAfterNewYear } = useTimeStore();
+  const { serverTime } = useTimeStore();
   const [timeLeft, setTimeLeft] = useState("00:00:00");
   const startTimeRef = useRef<number>(0);
   const serverTimeRef = useRef<Date | null>(null);
@@ -10,8 +10,10 @@ export function NewYearCountdown() {
   useEffect(() => {
     if (!serverTime) return;
 
-    // 서버 시간과 클라이언트 시작 시간을 저장
-    serverTimeRef.current = new Date(serverTime);
+    // 서버 시간(UTC)을 파싱하고 9시간 더해서 한국 시간으로 변환
+    const utcDate = new Date(serverTime);
+    const kstDate = new Date(utcDate.getTime() + 9 * 60 * 60 * 1000);
+    serverTimeRef.current = kstDate;
     startTimeRef.current = Date.now();
 
     const calculateTimeLeft = () => {
@@ -21,10 +23,13 @@ export function NewYearCountdown() {
       const elapsed = Date.now() - startTimeRef.current;
       const currentTime = new Date(serverTimeRef.current.getTime() + elapsed);
 
+      // 로컬 타임존 기준으로 년/월/일 확인
       const currentYear = currentTime.getFullYear();
+      const month = currentTime.getMonth();
+      const day = currentTime.getDate();
 
-      // 1월 1일 ~ 1월 14일 사이면 1월 1일부터 경과 시간 계산
-      if (isAfterNewYear) {
+      // 1월 1일 ~ 1월 14일이면 무조건 카운트업 모드
+      if (month === 0 && day >= 1 && day <= 14) {
         const newYear = new Date(currentYear, 0, 1, 0, 0, 0, 0);
         const diff = currentTime.getTime() - newYear.getTime();
 
@@ -35,13 +40,12 @@ export function NewYearCountdown() {
         return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
       }
 
-      // 12월이면 다음해 1월 1일 계산
-      const targetYear = currentYear + 1;
-      const newYear = new Date(targetYear, 0, 1, 0, 0, 0, 0);
-
-      const diff = newYear.getTime() - currentTime.getTime();
+      // 12월이면 다음해 1월 1일까지 카운트다운 (1초 느리게)
+      const nextYear = new Date(currentYear + 1, 0, 1, 0, 0, 0, 0);
+      const diff = nextYear.getTime() - currentTime.getTime() + 1000; // 1초 빼기
 
       if (diff <= 0) {
+        // 새해가 지났지만 아직 1월이 아님 (타임존 차이)
         return "00:00:00";
       }
 
@@ -61,7 +65,7 @@ export function NewYearCountdown() {
     }, 100);
 
     return () => clearInterval(interval);
-  }, [serverTime, isAfterNewYear]);
+  }, [serverTime]);
 
   return (
     <span className="font-counter font-extrabold text-[74px] text-gray-100">

--- a/src/stores/useTimeStore.ts
+++ b/src/stores/useTimeStore.ts
@@ -32,6 +32,8 @@ interface TimeState {
   fetchServerTime: () => Promise<void>;
 }
 
+let newYearTimeoutId: NodeJS.Timeout | null = null;
+
 export const useTimeStore = create<TimeState>((set) => ({
   serverTime: null,
   isNewYear: false,
@@ -46,6 +48,39 @@ export const useTimeStore = create<TimeState>((set) => ({
       const isNewYear = checkIsNewYearPeriod(serverTime);
       const isAfterNewYear = checkIsAfterNewYear(serverTime);
       set({ serverTime, isNewYear, isAfterNewYear, isLoading: false });
+
+      // 이전 타이머가 있으면 제거
+      if (newYearTimeoutId) {
+        clearTimeout(newYearTimeoutId);
+        newYearTimeoutId = null;
+      }
+
+      // 12월이고 아직 새해가 아니라면, 1월 1일 00:00:00까지의 시간 계산
+      if (!isAfterNewYear) {
+        // 서버 시간(UTC)을 한국 시간으로 변환
+        const utcDate = new Date(serverTime);
+        const kstDate = new Date(utcDate.getTime() + 9 * 60 * 60 * 1000);
+        
+        const currentYear = kstDate.getFullYear();
+        const month = kstDate.getMonth();
+        
+        // 12월인 경우에만 타이머 설정
+        if (month === 11) {
+          // 다음해 1월 1일 00:00:00 (한국 시간)
+          const nextYearKST = new Date(currentYear + 1, 0, 1, 0, 0, 0, 0);
+          
+          // 새해까지 남은 시간 계산
+          const serverNow = kstDate.getTime();
+          const timeUntilNewYear = nextYearKST.getTime() - serverNow;
+          
+          if (timeUntilNewYear > 0) {
+            newYearTimeoutId = setTimeout(() => {
+              set({ isAfterNewYear: true });
+              newYearTimeoutId = null;
+            }, timeUntilNewYear);
+          }
+        }
+      }
     } catch (error) {
       set({
         error:


### PR DESCRIPTION
<!-- PR 제목은 "[태그/#이슈번호] 작업 내용 요약" 으로 작성해주세요 -->
<!-- ex) [FEAT/#1] 로그인 페이지 UI 구현 -->

## Summary

> - #67 
_해당 PR에 대한 작업 내용을 요약하여 작성해주세요._

## Tasks

[서버 시간을 가져온 이후로 로컬에서 1월 1일 이후 판단 적용]

## To Reviewer

보드 페이지 카운트다운은 서버 시간은 가져오나 표기되는 것은 로컬 시간 기준입니다.
ex) 중국에서 접속한다고 하면 1시간 0분 1초가 남았는데 1초 후에 happy new year이 뜨는 겁니다. 즉, 한국에서의 경우 거의 차이가 없습니다.

## Screenshot


